### PR TITLE
 #437: TabsAdapterTest: Remove unnecessary holder3.

### DIFF
--- a/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
+++ b/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/TabsAdapterTest.kt
@@ -51,7 +51,7 @@ class TabsAdapterTest {
 
         val holder1 = adapter.createViewHolder(view, 0)
         val holder2 = adapter.createViewHolder(view, 0)
-        val holder3 = adapter.createViewHolder(view, 0)
+        
 
         val session1: Session = mock()
         val session2: Session = mock()
@@ -70,6 +70,6 @@ class TabsAdapterTest {
 
         verify(session1).unregister(holder1)
         verify(session2).unregister(holder2)
-        verifyNoMoreInteractions(holder3)
+        verifyNoMoreInteractions(session3)
     }
 }


### PR DESCRIPTION
val holder3 = adapter.createViewHolder(view, 0) is  the line that creates the val holder 3, and i have removed it and changed the verifyNoMoreInteractions back to (session3)